### PR TITLE
adding script to build for vercel deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "main": "index.js",
   "scripts": {
     "start": "node cors-fix-start.js",
-    "frontend": "cd client && vite"
+    "frontend": "cd client && vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
error on deploy: sh: line 1: vite: command not found
Error: Command "vite build" exited with 127